### PR TITLE
Feat: Optimizations to AudioChanger skin

### DIFF
--- a/AudioChanger/@Resources/VolumeControl.ini
+++ b/AudioChanger/@Resources/VolumeControl.ini
@@ -2,7 +2,7 @@
 Name=VolumeControl
 Author=Devo7v
 Information=Allows the user to control the volume using the mouse wheel. | Scrolling up or down will increase or decrease the volume. | Middle mouse click will mute/unmute the volume.
-Version=0.2
+Version=0.3
 License=Creative Commons Attribution-Non-Commercial-Share Alike 3.0
 
 [MeasureMediaKey]
@@ -10,8 +10,9 @@ Measure=MediaKey
 
 [VolumeTarget]
 Meter=Shape
-Shape=Rectangle (#Size#/12),(#Size#/12),#Size#,#Size# | Fill Color 0,0,0,1 | StrokeWidth 0
-MouseScrollUpAction=[!CommandMeasure "MeasureMediaKey" "VolumeUp"][!Update]
-MouseScrollDownAction=[!CommandMeasure "MeasureMediaKey" "VolumeDown"][!Update]
-MiddleMouseDownAction=[!CommandMeasure "MeasureMediaKey" "VolumeMute"][!Update]
+Shape=Rectangle (#Size#/12),(#Size#/12),#Size#,#Size# | Fill Color 0,0,0,0 | StrokeWidth 0
+MouseScrollUpAction=[!CommandMeasure "MeasureMediaKey" "VolumeUp"][!UpdateMeasure MeasureAudioDevice]
+MouseScrollDownAction=[!CommandMeasure "MeasureMediaKey" "VolumeDown"][!UpdateMeasure MeasureAudioDevice]
+MiddleMouseDownAction=[!CommandMeasure "MeasureMediaKey" "VolumeMute"][!UpdateMeasure MeasureAudioDevice]
+RightMouseUpAction=[!CommandMeasure "MeasureMediaKey" "VolumeMute"][!UpdateMeasure MeasureAudioDevice]
 Hidden=0

--- a/AudioChanger/AudioChanger.ini
+++ b/AudioChanger/AudioChanger.ini
@@ -1,5 +1,6 @@
 [Rainmeter]
 Update=1000
+DefaultUpdateDivider=-1
 DynamicWindowSize=1
 AccurateText=1
 
@@ -21,6 +22,7 @@ BackgroundColor=0,0,0,1
 [MeasureAudioDevice]
 Measure=Plugin
 Plugin=Win7AudioPlugin
+UpdateDivider=1
 Substitute="Speaker/HP":"1","Headphones":"2","Headset":"3"
 IfMatch=1
 IfMatchAction=[!ShowMeter "MeterSpeakers"][!HideMeter "MeterHeadphones"][!HideMeter "MeterHeadset"][!Redraw]
@@ -37,7 +39,7 @@ SolidColor=#BackgroundColor#
 X=(#Size#/12)
 Y=(#Size#/12)
 H=#Size#
-LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"]
+LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"][!UpdateMeasure MeasureAudioDevice]
 Hidden=1
 
 [MeterHeadphones]
@@ -48,7 +50,7 @@ SolidColor=#BackgroundColor#
 X=r
 Y=r
 H=#Size#
-LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"]
+LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"][!UpdateMeasure MeasureAudioDevice]
 Hidden=1
 
 [MeterHeadset]
@@ -59,7 +61,7 @@ SolidColor=#BackgroundColor#
 X=r
 Y=r
 H=#Size#
-LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"]
+LeftMouseUpAction=[!CommandMeasure MeasureAudioDevice "ToggleNext"][!UpdateMeasure MeasureAudioDevice]
 Hidden=1
 
 [Includes]


### PR DESCRIPTION
Started using this skin and felt like making some minor improvements to how updates/redraws are handled. Hope these are helpful :)

- When switching audio via skin, redraw immediately instead of waiting 0-1s for next update
- Don't update any components that don't need to update
- VolumeTarget doesn't need alpha color=1 to function, as long as it's not hidden
- Increment version